### PR TITLE
Add Support for AWS Secrets Manager Provider

### DIFF
--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -88,3 +88,14 @@ Return the appropriate apiVersion for network policy.
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the secrets provider class to use
+*/}}
+{{- define "pgadmin.secretsProviderClassName" -}}
+{{- if .Values.secretProviderClass.create }}
+{{- default (include "pgadmin.fullname" .) .Values.secretProviderClass.name }}
+{{- else }}
+{{- default "default" .Values.secretProviderClass.name }}
+{{- end }}
+{{- end }}

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -161,6 +161,9 @@ spec:
           {{- if .Values.extraVolumeMounts }}
             {{- .Values.extraVolumeMounts | toYaml | nindent 12 }}
           {{- end }}
+          {{- if .Values.secretProviderClass.create }}
+            {{- toYaml .Values.secretProviderClass.volumeMounts | nindent 12 }}
+          {{- end }}
           resources:
             {{- .Values.resources | toYaml | nindent 12 }}
     {{- with .Values.extraContainers }}
@@ -196,6 +199,9 @@ spec:
             items:
             - key: servers.json
               path: servers.json
+      {{- end }}
+      {{- if .Values.secretProviderClass.create }}
+        {{- toYaml .Values.secretProviderClass.volumes | nindent 8 }}
       {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/pgadmin4/templates/secretproviderclass.yaml
+++ b/charts/pgadmin4/templates/secretproviderclass.yaml
@@ -1,0 +1,47 @@
+# A secret provider class to load AWS Secret Manager's secrets.
+# The secrets would be loaded as a file with the option to load them into environment variables
+
+{{- if .Values.secretProviderClass.create -}}
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: {{ include "pgadmin.secretsProviderClassName" . }}
+  labels:
+    {{- include "pgadmin.labels" . | nindent 4 }}
+  {{- with .Values.secretProviderClass.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  provider: aws
+  {{- if .Values.secretProviderClass.createEnvironmentVariables }}
+  secretObjects:                                 
+  - secretName: {{ printf "%s-asm-secrets" (include "pgadmin.secretsProviderClassName" .) }}
+    type: Opaque
+    labels:
+        {{- include "pgadmin.labels" . | nindent 6 }}
+    data: 
+    {{- range $secret := .Values.secretProviderClass.secrets }} 
+    {{- range $env := $secret.environmentVariables }} 
+    - objectName: {{ printf "%s%s" $secret.asmName ( ternary (printf ":%s" $env.secretKey) "" (ne ($env.secretKey) "SELF")) | replace "/" ":" }}
+      key: {{ $env.environmentVariableName }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+  parameters:
+    pathTranslation: ":"
+    objects: |
+      {{- range $secret := .Values.secretProviderClass.secrets }} 
+      - objectName: "{{ $secret.asmName }}"
+        objectType: secretsmanager
+        {{- if $secret.environmentVariables }}
+        jmesPath:
+        {{- range $env := $secret.environmentVariables }}
+        {{- if ne $env.secretKey "SELF" }}
+            - path: "{{ $env.secretKey }}"
+              objectAlias: "{{ printf "%s:%s" $secret.asmName $env.secretKey | replace "/" ":" }}"
+        {{- end }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/charts/pgadmin4/values-override.yaml
+++ b/charts/pgadmin4/values-override.yaml
@@ -1,0 +1,54 @@
+nodeSelector:
+  worker_group: services
+
+existingSecret: pgadmin4-asm-secrets
+env:
+  email: issam@gmail.com
+
+serviceAccount:
+  create: true
+  annotations:
+    # Tyhe IAM role that can be assumend by the service account and can read the AWS Secret Manager secret
+    eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/pgadmin4-sa-role # AWSAccount number should be replaced
+
+persistentVolume:
+  storageClass: csi-storage-gp3
+
+service:
+  type: NodePort
+  port: 80
+
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
+    alb.ingress.kubernetes.io/target-node-labels: "worker_group=services"
+    alb.ingress.kubernetes.io/group.name: services-ingress
+  hosts:
+    - host: pgadmin.services.sampledomain.com # This is a smaple domain, it should be replaced with the right one
+      paths:
+        - path: /
+          pathType: Prefix
+
+secretProviderClass:
+  create: true
+  createEnvironmentVariables: true
+  secrets:
+    - asmName: pgadmin_password # Name of the AWS Secrets Manager
+      environmentVariables:
+        - environmentVariableName: password # The Secret Key that the `PGADMIN_DEFAULT_PASSWORD` environment variable will point to
+          secretKey: SELF # Read the whole value as it is, no json parsing
+  volumeMounts:
+    - name: aws-secrets
+      mountPath: /etc/sm
+      readOnly: true
+  volumes:
+    - name: aws-secrets
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: pgadmin4

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -30,7 +30,8 @@ service:
   # targetPort: 4181 To be used with a proxy extraContainer
   portName: http
 
-  annotations: {}
+  annotations:
+    {}
     ## Special annotations at the service level, e.g
     ## this will set vnet internal IP's rather than public ip's
     ## service.beta.kubernetes.io/azure-load-balancer-internal: "true"
@@ -55,7 +56,8 @@ serviceAccount:
 ## Strategy used to replace old Pods by new ones
 ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 ##
-strategy: {}
+strategy:
+  {}
   # type: RollingUpdate
   # rollingUpdate:
   #   maxSurge: 0
@@ -87,7 +89,8 @@ networkPolicy:
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # ingressClassName: ""
@@ -103,14 +106,16 @@ ingress:
 
 # Additional config maps to be mounted inside a container
 # Can be used to map config maps for sidecar as well
-extraConfigmapMounts: []
+extraConfigmapMounts:
+  []
   # - name: certs-configmap
   #   mountPath: /etc/ssl/certs
   #   subPath: ca-certificates.crt # (optional)
   #   configMap: certs-configmap
   #   readOnly: true
 
-extraSecretMounts: []
+extraSecretMounts:
+  []
   # - name: pgpassfile
   #   secret: pgpassfile
   #   subPath: pgpassfile
@@ -148,8 +153,8 @@ existingSecret: ""
 ## Needed chart reinstall for apply changes
 env:
   # can be email or nickname
-  email: chart@example.local
-  password: SuperSecret
+  # email: chart@example.local
+  # password: SuperSecret
   # pgpassfile: /var/lib/pgadmin/storage/pgadmin/file.pgpass
 
   # set context path for application (e.g. /pgadmin4/*)
@@ -170,12 +175,14 @@ env:
   #   value: "8080"
 
 ## Additional environment variables from ConfigMaps
-envVarsFromConfigMaps: []
+envVarsFromConfigMaps:
+  []
   # - array-of
   # - config-map-names
 
 ## Additional environment variables from Secrets
-envVarsFromSecrets: []
+envVarsFromSecrets:
+  []
   # - array-of
   # - secret-names
 
@@ -260,7 +267,8 @@ extraInitContainers: |
 containerPorts:
   http: 80
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -302,7 +310,8 @@ podAnnotations: {}
 
 ## Pod labels
 ##
-podLabels: {}
+podLabels:
+  {}
   # key1: value1
   # key2: value2
 
@@ -320,14 +329,25 @@ test:
     tag: latest
   ## Resources request/limit for test-connection Pod
   resources: {}
-#     limits:
-#       cpu: 25m
-#       memory: 16Mi
-#     requests:
-#       cpu: 50m
-#       memory: 32Mi
+  #     limits:
+  #       cpu: 25m
+  #       memory: 16Mi
+  #     requests:
+  #       cpu: 50m
+  #       memory: 32Mi
   ## Security context for test-connection Pod
   securityContext:
     runAsUser: 5051
     runAsGroup: 5051
     fsGroup: 5051
+
+secretProviderClass:
+  # Specifies whether a secrets provider class should be created
+  create: false
+  # Annotations to add to the secrets provider class
+  annotations: {}
+  # The name of the secrets provider class to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # Provide the secrets, full path name, list.
+  secrets: []


### PR DESCRIPTION
#### What this PR does / why we need it:

I wanted to load the pgadmin4 root password from the AWS Secrets Manager. To do so, I added integration for [CSI Secret driver ](https://secrets-store-csi-driver.sigs.k8s.io/) and [AWS Secret Provider](https://github.com/aws/secrets-store-csi-driver-provider-aws) by introducing `secretProviderClass` implementation. This class enables loading AWS Secrets Manager secrets as mounted files in the container and creating them as K8s secrets to be referenced by environment variables.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
